### PR TITLE
Redmine 3.3対応 (#2)

### DIFF
--- a/app/views/layouts/_view_layouts_base_body_bottom_hook.html.erb
+++ b/app/views/layouts/_view_layouts_base_body_bottom_hook.html.erb
@@ -1,7 +1,11 @@
 <% if @version.present? && ('versions' == params[:controller]) && ['new', 'edit'].include?(params[:action]) %>
   <p style='display: none;'>
     <%= label :version, :start_date %>
-    <%= text_field :version, :start_date, size: 10, value: @version.start_date %>
+    <% if Redmine::VERSION.to_s.to_f < 3.3 %>
+      <%= text_field :version, :start_date, size: 10 %>
+    <% else %>
+      <%= date_field :version, :start_date, size: 10 %>
+    <% end %>
     <%= calendar_for('version_start_date') %>
   </p>
 <% end %>

--- a/assets/javascripts/redmine_version_start_date.js
+++ b/assets/javascripts/redmine_version_start_date.js
@@ -1,6 +1,10 @@
 $(function(){
-  var $org_elements =
-    $('.controller-versions.action-index h3.version + p, .controller-versions.action-show #roadmap > p:first-child');
+  var selectors = [
+    '.controller-versions.action-index h3.version + p',
+    '#roadmap > p:first-child',
+    '.version-overview > p:first-child'
+  ];
+  var $org_elements = $(selectors.join(','));
   var $mod_elements = $('.redmine_version_start_date');
   $.each($mod_elements, function(i, mod_element){
     if(!$(mod_element).hasClass('none')){


### PR DESCRIPTION
* redmine3.3にて期日の表示切替時に発生していたエラーを解消

* Versionの編集フォームにて、開始日のUIがテキストフィールドのままになっている現象を解消